### PR TITLE
Slightly modify env var names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Comparing the performances of web-mqtt, web-stomp and web-amqp. Metrics
 ## Environment variables
 
 - set `BROKER_USERNAME` and `BROKER_PASSWORD` for credentials no matter which protocol you choose
-- set `MQTT_BROKER`, `STOM_BROKER` or `AMQP_BROKER` respectively for
+- set `MQTT_BROKER`, `STOMP_BROKER` or `AMQP_BROKER` respectively for
   the full websocket URL (including protocol, host, port and path). For
   example ```export STOMP_BROKER=ws://127.0.0.1:15674/ws```
 

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,9 @@ Comparing the performances of web-mqtt, web-stomp and web-amqp. Metrics
 
 ## Environment variables
 
+The below values can be set either as OS env vars or in a `.env`
+file. See [example](web_mqtt/.env-example)
+
 - set `BROKER_USERNAME` and `BROKER_PASSWORD` for credentials no matter which protocol you choose
 - set `MQTT_BROKER`, `STOMP_BROKER` or `AMQP_BROKER` respectively for
   the full websocket URL (including protocol, host, port and path). For

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,15 @@ Comparing the performances of web-mqtt, web-stomp and web-amqp. Metrics
 - Navigate into project: `cd websockets-rabbitmq-benchmarks`
 - Install dependencies: `npm install`
 
+## Environment variables
+
+- set `BROKER_USERNAME` and `BROKER_PASSWORD` for credentials no matter which protocol you choose
+- set `MQTT_BROKER`, `STOM_BROKER` or `AMQP_BROKER` respectively for
+  the full websocket URL (including protocol, host, port and path). For
+  example ```export STOMP_BROKER=ws://127.0.0.1:15674/ws```
+
+- set `VHOST` for the STOMP client
+
 ## Usage
 You can either test idle connections or connections with messages
 

--- a/web_amqp/config.js
+++ b/web_amqp/config.js
@@ -7,8 +7,8 @@ const nodeEnv = process.env.NODE_ENV
 
 const clientSettings = {
   host: process.env.AMQP_BROKER,
-  username: process.env.USERNAME,
-  password: process.env.PASSWORD
+  username: process.env.BROKER_USERNAME,
+  password: process.env.BROKER_PASSWORD
 }
 
 export { nodeEnv, clientSettings }

--- a/web_mqtt/.env-example
+++ b/web_mqtt/.env-example
@@ -1,3 +1,3 @@
 MQTT_BROKER="wss://cluster-name:{port}/ws/mqtt"
-USERNAME=""
-PASSWORD=""
+BROKER_USERNAME=""
+BROKER_PASSWORD=""

--- a/web_mqtt/config.js
+++ b/web_mqtt/config.js
@@ -6,8 +6,8 @@ const clientSettings = {
     host: process.env.MQTT_BROKER,
     options: {
         keepalive: 0,
-        username: process.env.USERNAME,
-        password: process.env.PASSWORD,
+        username: process.env.BROKER_USERNAME,
+        password: process.env.BROKER_PASSWORD,
         connectTimeout: 60000,
         reconnectPeriod: 20000,
         rejectUnauthorized: false

--- a/web_stomp/config.js
+++ b/web_stomp/config.js
@@ -6,10 +6,10 @@ dotenv.config()
 const nodeEnv = process.env.NODE_ENV
 
 const clientSettings = {
-  brokerURL: `wss://${process.env.BROKER}/ws`,
+  brokerURL: process.env.STOMP_BROKER,
   connectHeaders: {
-    login: process.env.USERNAME,
-    passcode: process.env.PASSWORD,
+    login: process.env.BROKER_USERNAME,
+    passcode: process.env.BROKER_PASSWORD,
     host: process.env.VHOST,
   },
   reconnectDelay: 100,


### PR DESCRIPTION
Main motivation for the change: rename USERNAME to BROKER_USERNAME because on MacOs (at least on my machine) USERNAME is hardcoded to the name of the logged in user and cannot be modified.

btw: great tool, very easy to generate some Web-MQTT/Web-STOMP connections and traffic.